### PR TITLE
Fix gem version to support rubygems < 2.1

### DIFF
--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -26,7 +26,19 @@ module YARD
 
           version
         end
+
+        # The full gem version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
+        # {http://guides.rubygems.org/specification-reference/#version RubyGems versioning} format.
+        #
+        # @return [String] '{MAJOR}.{MINOR}.{PATCH}' on master.  '{MAJOR}.{MINOR}.{PATCH}.{PRERELEASE}' on any branch
+        #   other than master.
+        def self.gem
+          full.gsub('-', '.pre.')
+        end
       end
+
+      # @see Version.gem
+      GEM_VERSION = Version.gem
 
       # @see Version.full
       VERSION = Version.full

--- a/yard-metasploit-erd.gemspec
+++ b/yard-metasploit-erd.gemspec
@@ -5,7 +5,7 @@ require 'yard/metasploit/erd/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'yard-metasploit-erd'
-  spec.version       = YARD::Metasploit::ERD::VERSION
+  spec.version       = YARD::Metasploit::ERD::GEM_VERSION
   spec.authors       = ['Luke Imhoff']
   spec.email         = ['luke_imhoff@rapid7.com']
   spec.summary       = 'YARD plugin that add Metasploit::ERDs to namespaces and classes'


### PR DESCRIPTION
https://jira.tor.rapid7.com/browse/MSP-10714
## Verification Steps
- [x] `gem update --system 1.8.23`
- [x] `bundle`
- [x] VERIFY: bundle completes successfully
## Land
- [x] Merge this PR
- [x] Remove `PRERELEASE` constant and comment from `lib/yard/metasploit/erd/version.rb`.  Commit and push.
