### PR TITLE
RSpec 3.1

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --format documentation
+--require spec_helper

--- a/lib/yard/metasploit/erd.rb
+++ b/lib/yard/metasploit/erd.rb
@@ -1,4 +1,10 @@
 #
+# Standard Library
+#
+
+require 'pathname'
+
+#
 # Gems
 #
 

--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -9,6 +9,8 @@ module YARD
         MINOR = 0
         # The patch number, scoped to the {MINOR} version number.
         PATCH = 2
+        # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version number.
+        PRERELEASE = 'rspec-3.1'
 
         # The full version string, including the {MAJOR}, {MINOR}, {PATCH}, and optionally, the {PRERELEASE} in the
         # {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0} format.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'bundler/setup'
 
 # require before 'metasploit/erd' so coverage is shown for files required by 'yard/metasploit/erd'
 require 'simplecov'
@@ -14,4 +14,64 @@ else
   ]
 end
 
+#
+# Project
+#
+
 require 'yard/metasploit/erd'
+
+RSpec.configure do |config|
+  config.expose_dsl_globally = false
+
+  # These two settings work together to allow you to limit a spec run
+  # to individual examples or groups you care about by tagging them with
+  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  # get run.
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
+  # allow more verbose output when running an individual spec file.
+  if config.files_to_run.one?
+    # RSpec filters the backtrace by default so as not to be so noisy.
+    # This causes the full backtrace to be printed when running a single
+    # spec file (e.g. to troubleshoot a particular spec failure).
+    config.full_backtrace = true
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+
+  config.expect_with :rspec do |expectations|
+    # Enable only the newer, non-monkey-patching expect syntax.
+    expectations.syntax = :expect
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Enable only the newer, non-monkey-patching expect syntax.
+    # For more details, see:
+    #   - http://teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+    mocks.syntax = :expect
+
+    mocks.patch_marshal_to_support_partial_doubles = false
+
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object.
+    mocks.verify_partial_doubles = true
+  end
+end

--- a/spec/yard/metasploit/erd/version_spec.rb
+++ b/spec/yard/metasploit/erd/version_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 require 'active_support/core_ext/object/blank'
 
 RSpec.describe YARD::Metasploit::ERD::Version do

--- a/spec/yard/metasploit/erd/version_spec.rb
+++ b/spec/yard/metasploit/erd/version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 require 'active_support/core_ext/object/blank'
 
-describe YARD::Metasploit::ERD::Version do
+RSpec.describe YARD::Metasploit::ERD::Version do
   context 'CONSTANTS' do
     context 'MAJOR' do
       subject(:major) do

--- a/spec/yard/metasploit/erd_spec.rb
+++ b/spec/yard/metasploit/erd_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe YARD::Metasploit::ERD do
   context 'CONSTANTS' do
     context 'VERSION' do

--- a/spec/yard/metasploit/erd_spec.rb
+++ b/spec/yard/metasploit/erd_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe YARD::Metasploit::ERD do
+RSpec.describe YARD::Metasploit::ERD do
   context 'CONSTANTS' do
     context 'VERSION' do
       subject(:version) do

--- a/yard-metasploit-erd.gemspec
+++ b/yard-metasploit-erd.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 10.3'
-  spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'rspec', '~> 3.1'
 
   # Generates namespace Module and Class<ActiveRecord::Base> specific ERDs for use in templates
   spec.add_runtime_dependency 'metasploit-erd', '0.0.1'


### PR DESCRIPTION
MSP-12258

Upgrade to RSpec 3.1 as using metasploit-version requires rspec 3.1.

# Verification Steps
- [x] `rm Gemfile.lock`
- [x] `bundle install`

## RSpec version
- [x] `bundle list | grep rspec`
- [x] VERIFY `rspec` version is >= 3.1.

## Specs
- [x] `rake spec`
- [x] VERIFY no failures