### PR TITLE
Allow YARD that can handle required keyword argments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,8 @@
 * Bug Fixes
 * Deprecations
 * Incompatible Changes
+
+# v0.0.4
+
+* Bug fixes
+  * [#6](https://github.com/rapid7/yard-metasploit-erd/pull/6): Remove version restriction on YARD to enable YARD (> 0.8.7.4) that supports required keyword arguments - [@limhoff-r7](https://github.com/limhoff-r7)

--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -12,9 +12,9 @@ module YARD
         # The minor version number, scoped to the {MAJOR} version number.
         MINOR = 0
         # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-        PATCH = 3
-        # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
-        PRERELEASE = 'metasploit-version'
+        PATCH = 4
+        # The pre-release version, scoped to {MAJOR}, {MINOR}, and {PATCH} version numbers.
+        PRERELEASE = 'required-keyword-arguments'
 
         #
         # Module Methods

--- a/yard-metasploit-erd.gemspec
+++ b/yard-metasploit-erd.gemspec
@@ -30,7 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'metasploit-erd', '0.0.1'
   # RailsERD::Domain is used directly to generate the _index.html ERD.
   spec.add_runtime_dependency 'rails-erd'
-  # documentation
-  # 0.8.7.4 has a bug where setters are not documented when @!attribute is used
-  spec.add_runtime_dependency 'yard', '<= 0.8.7.4'
+  spec.add_runtime_dependency 'yard'
 end


### PR DESCRIPTION
MSP-12256

YARD does not need to be restricted to <= 0.8.7.4.  The restriction was necessary due to a misunderstanding of when to use `@!attribute`.  Additionally, 0.8.7.4 errors when parsing required keyword arguments, so newer YARD versions, which don't error need to be allowed.

# Pre-verification Steps
- [x] Merge #5 

# Verification Steps
- [x] `rm Gemfile.lock`
- [x] `bundle install`

## Specs
- [x] `rake spec`
- [x] VERIFY no failures

## Docs
- [x] `rake yard`
- [x] VERIFY no warnings
- [x] VERIFY no undocumented modules, classes, constants, or methods.

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/yard/metasploit/erd/version.rb`
- [ ] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [ ] gem build *.gemspec
- [ ] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [ ] `rake spec`
- [ ] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release

Complete these steps on master

## `VERSION`

### Compatible changes

* [`PATCH`](lib/yard/metasploit/erd/version.rb) has been incremented for the bug fix in the [CHANGELOG.md](CHANGELOG.md).

## Release to rubygems.org

## jruby
- [ ] `rvm use jruby@yard-metasploit-erd`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`

## ruby-2.1
- [ ] `rvm use ruby-2.1@yard-metasploit-erd`
- [ ] `rm Gemfile.lock`
- [ ] `bundle install`
- [ ] `rake release`