### PR TITLE
Optimize build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
   - 2.1
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+cache: bundler
 language: ruby
 rvm:
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: ruby
 rvm:
   - 2.1
-  - jruby
-  - rbx

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,12 +68,6 @@ decide to remain pre-1.0.0 or (2) advance to 1.0.0.
 
 ## Release to rubygems.org
 
-## jruby
-- [ ] `rvm use jruby@yard-metasploit-erd`
-- [ ] `rm Gemfile.lock`
-- [ ] `bundle install`
-- [ ] `rake release`
-
 ## ruby-2.1
 - [ ] `rvm use ruby-2.1@yard-metasploit-erd`
 - [ ] `rm Gemfile.lock`

--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -12,7 +12,9 @@ module YARD
         # The minor version number, scoped to the {MAJOR} version number.
         MINOR = 0
         # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
-        PATCH = 4
+        PATCH = 5
+        # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+        PRERELEASE = 'optimize-build-configuration'
 
         #
         # Module Methods


### PR DESCRIPTION
MSP-12600

Drop jruby and rbx to free build slots for the rapid7 account since those engines aren't supported.  Switch to containerized builds for faster build startup and running with the ability to cache bundler dependencies.

# Verification Steps
- [x] Go to the [PR build](https://travis-ci.org/rapid7/yard-metasploit-erd/builds/59551939)

## Ruby engines
- [x] VERIFY there is NOT a jruby build on travis-ci
- [x] VERIFY there is NOT an rbx build on travis-ci

## Containizered builds
- [x] VERIFY containerized build is active: "This job is running on container-based infrastructure"
- [x] VERIFY bundler cache is active: "store build cache", "bundler clean"

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [x] Edit `lib/yard/metasploit/erd/version.rb`
- [x] Remove `PRERELEASE` and its comment as `PRERELEASE` is not defined on master.

## Gem build
- [x] gem build *.gemspec
- [x] VERIFY the gem has no '.pre' version suffix.

## RSpec
- [x] `rake spec`
- [x] VERIFY version examples pass without failures

## Commit & Push
- [ ] `git commit -a`
- [ ] `git push origin master`

# Release Steps

No release is necessary as this is a travis-ci only change.