### PR TITLE
Update RELEASING.md to 1.0.0+ semantic versioning rules.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -40,18 +40,21 @@ Complete these steps on DESTINATION
 
 The entries in the [CHANGELOG.md](CHANGELOG.md) can be used to help determine how the `VERSION` should be bumped.
 
-### Compatible changes
+### Bug fixes
 
-If the [CHANGELOG.md](CHANGELOG.md) contains only Enhancements, Bug Fixes, and/or Deprecations for the Next Release then
-increment [`PATCH`](lib/yard/metasploit/erd/version.rb).
+If the [CHANGELOG.md](CHANGELOG.md) contains only Bug Fixes for the Next Release, then increment
+[`PATCH`](lib/yard/metasploit/erd/version.rb).
 
-### Incompatible changes
+### Compatible API changes
 
-If the [CHANGELOG.md](CHANGELOG.md) contains any Incompatible Changes for the Next Release, then you can either (1)
-decide to remain pre-1.0.0 or (2) advance to 1.0.0.
+If the [CHANGELOG.md](CHANGELOG.md) contains any Enhancements or Deprecations, then increment
+[`MINOR`](lib/yard/metasploit/erd/version.rb) and reset [`PATCH`](lib/yard/metasploit/erd/version.rb) to `0`.
 
-1. To remain pre-1..0.0, then increment [`MINOR`](lib/yard/metasploit/erd/version.rb) and reset [`PATCH`](lib/yard/metasploit/erd/version.rb) to `0`.
-2. To advance to 1.0.0, increment [`MAJOR`](lib/yard/metasploit/erd/version.rb) and reset [`MINOR`](lib/yard/metasploit/erd/version.rb and [`PATCH`](lib/yard/metasploit/erd/version.rb) to `0`.
+### Incompatible API changes
+
+If the [CHANGELOG.md](CHANGELOG.md) contains any Incompatible Change, then increment
+[`MAJOR`](lib/yard/metasploit/erd/version.rb) and reset [`MINOR`](lib/yard/metasploit/erd/version.rb and
+[`PATCH`](lib/yard/metasploit/erd/version.rb) to `0`.
 
 ## Setup [CHANGELOG.md](CHANGELOG.md) for next release
 

--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -1,6 +1,6 @@
-module YARD
+module Yard
   module Metasploit
-    module ERD
+    module Erd
       # Holds components of {VERSION} as defined by {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0}.
       module Version
         #
@@ -11,10 +11,10 @@ module YARD
         MAJOR = 1
         # The minor version number, scoped to the {MAJOR} version number.
         MINOR = 0
-        # The patch number, scoped to the {MINOR} version number.
+        # The patch version number, scoped to the {MAJOR} and {MINOR} version numbers.
         PATCH = 0
-        # the prerelease identifier
-        PRERELEASE = 'rails-4.0'
+        # The prerelease version, scoped to the {MAJOR}, {MINOR}, and {PATCH} version numbers.
+        PRERELEASE = 'releasing-1-0-0-plus'
 
         # The full version string, including the {YARD::Metasploit::ERD::Version::MAJOR},
         # {YARD::Metasploit::ERD::Version::MINOR}, {YARD::Metasploit::ERD::Version::PATCH}, and optionally, the

--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -1,4 +1,4 @@
-module Yard
+module YARD
   module Metasploit
     module Erd
       # Holds components of {VERSION} as defined by {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0}.

--- a/lib/yard/metasploit/erd/version.rb
+++ b/lib/yard/metasploit/erd/version.rb
@@ -1,6 +1,6 @@
 module YARD
   module Metasploit
-    module Erd
+    module ERD
       # Holds components of {VERSION} as defined by {http://semver.org/spec/v2.0.0.html semantic versioning v2.0.0}.
       module Version
         #


### PR DESCRIPTION
MSP-12646

# Verification Steps
- [x] Read changes RELEASING.md
- [x] **Verify** rules match http://semver.org/spec/v2.0.0.html

# Post-merge Steps

Perform these steps prior to pushing to master or the build will be broke on master.

## Version
- [ ] Edit `lib/yard/metasploit/erd/version.rb`
- [ ] Change `PRERELEASE` back to `'staging/rails-4.0'`
