### PR TITLE
Fixed a deprecation 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,10 @@ require 'coveralls'
 #   # don't generate local report as it is inaccessible on travis-ci, which is why coveralls is being used.
 #   SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 # else
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
       # either generate the local report
       SimpleCov::Formatter::HTMLFormatter
-  ]
+  )
 # end
 
 #


### PR DESCRIPTION
Where the [] syntax needed to be replaced with the .new() syntax

Verification Steps

- [x] Run rspec 
- [x] Ensure that the test passes and that there are no deprecations logged.